### PR TITLE
Fix document type mapping for `study`

### DIFF
--- a/command-migration/src/main/java/org/qucosa/migration/mappings/MappingFunctions.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/MappingFunctions.java
@@ -78,7 +78,7 @@ public class MappingFunctions {
         put("proceeding", "proceeding");
         put("report", "report");
         put("research_paper", "research_paper");
-        put("study", "study");
+        put("study", "text");
     }};
 
     static String dateEncoding(BigInteger year) {


### PR DESCRIPTION
OPUS type `study` should be mapped to type `text`

https://jira.slub-dresden.de/browse/CMR-161