### PR TITLE
CMR-208: Implements specific Document-Type-Mapping

### DIFF
--- a/command-migration/src/main/java/org/qucosa/migration/mappings/DocumentTypeMapping.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/DocumentTypeMapping.java
@@ -28,7 +28,7 @@ public class DocumentTypeMapping {
     public void mapDocumentType(Document opus, InfoType info, ChangeLog changeLog) {
         final String type = opus.getType();
         if (type != null && !type.isEmpty()) {
-            final String encodedType = documentTypeEncoding(type);
+            final String encodedType = documentTypeEncoding(type, opus.getDocumentId());
             if (info.getDocumentType() == null || !info.getDocumentType().equals(encodedType)) {
                 info.setDocumentType(encodedType);
                 changeLog.log(SLUB_INFO);

--- a/command-migration/src/main/java/org/qucosa/migration/mappings/MappingFunctions.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/MappingFunctions.java
@@ -81,6 +81,19 @@ public class MappingFunctions {
         put("study", "text");
     }};
 
+    private static final HashMap<String, String> specificDocumentIdMapping = new HashMap<String, String>() {{
+        put("22751", "series");
+        put("11387", "series");
+        put("11278", "series");
+        put("11167", "series");
+        put("14800", "series");
+        put("15304", "series");
+        put("17955", "series");
+        put("18657", "series");
+        put("11483", "series");
+        put("20965", "series");
+    }};
+
     static String dateEncoding(BigInteger year) {
         if ((year == null) || year.equals(BigInteger.ZERO)) return null;
 
@@ -170,7 +183,10 @@ public class MappingFunctions {
         return (list.isEmpty()) ? null : list.get(0);
     }
 
-    static String documentTypeEncoding(String type) {
+    static String documentTypeEncoding(String type, String opusDocumentId) {
+        if (specificDocumentIdMapping.containsKey(opusDocumentId)) {
+            return specificDocumentIdMapping.get(opusDocumentId);
+        }
         return typeMapping.get(type);
     }
 

--- a/command-migration/src/test/java/org/qucosa/migration/mappings/DocumentTypeMappingTest.java
+++ b/command-migration/src/test/java/org/qucosa/migration/mappings/DocumentTypeMappingTest.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXpathExists;
+import static org.custommonkey.xmlunit.XMLAssert.assertXpathNotExists;
 import static org.junit.Assert.assertTrue;
 
 public class DocumentTypeMappingTest extends MappingTestBase {
@@ -67,6 +68,26 @@ public class DocumentTypeMappingTest extends MappingTestBase {
         assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
         assertXpathExists(
                 "//slub:documentType[text()='periodical']",
+                info.getDomNode().getOwnerDocument());
+    }
+
+    /*
+    Tests specific Document-Type-Mapping.
+    Certain documents should be mapped to "series" type, series-type had no corresponding mapping in Opus
+    and therefore became Opus-"journals" which usually maps to "periodical".
+     */
+    @Test
+    public void properlyEncodesSpecificDocumentType() throws Exception {
+        opus.setDocumentId("22751");
+        opus.setType("journal");
+
+        documentTypeMapping.mapDocumentType(opus, info, changeLog);
+
+        assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
+        assertXpathNotExists(
+                "//slub:documentType[text()='periodical']",
+                info.getDomNode().getOwnerDocument());
+        assertXpathExists("//slub:documentType[text()='series']",
                 info.getDomNode().getOwnerDocument());
     }
 


### PR DESCRIPTION
for certain documents which had the wrong document type in opus ("journal")
due to no corresponding type in opus for "Schriftenreihe"/"series"
https://jira.slub-dresden.de/browse/CMR-208