### PR TITLE
Adjust corporate-informations.

### DIFF
--- a/command-migration/src/main/java/org/qucosa/migration/mappings/AdministrativeInformationMapping.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/AdministrativeInformationMapping.java
@@ -82,7 +82,6 @@ public class AdministrativeInformationMapping {
             if (nd == null) {
                 nd = mods.addNewName();
                 nd.setType2(CORPORATE);
-                nd.setDisplayLabel("mapping-hack-university");
                 changeLog.log(MODS);
             }
 
@@ -132,7 +131,6 @@ public class AdministrativeInformationMapping {
                 rtd.setType(CODE);
                 rtd.setAuthority("marcrelator");
                 rtd.setAuthorityURI(LOC_GOV_VOCABULARY_RELATORS);
-                rtd.setValueURI(LOC_GOV_VOCABULARY_RELATORS + "/" + role);
                 rtd.setStringValue(role);
                 changeLog.log(MODS);
             }
@@ -186,14 +184,6 @@ public class AdministrativeInformationMapping {
                         changeLog.log(MODS);
                     }
                 }
-            }
-
-            // ensure mods:extension/slub:info/slub:corporation/slub:university
-            XmlString university = (XmlString) select("slub:university", corporation);
-            if (university == null) {
-                university = corporation.addNewUniversity();
-                university.setStringValue(publisherName);
-                changeLog.log(MODS);
             }
 
             if (embedNewInfoExtensionAfterwards) {

--- a/command-migration/src/main/java/org/qucosa/migration/mappings/InstitutionsMapping.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/InstitutionsMapping.java
@@ -210,7 +210,6 @@ public class InstitutionsMapping {
             rtd.setType(CODE);
             rtd.setAuthority("marcrelator");
             rtd.setAuthorityURI(LOC_GOV_VOCABULARY_RELATORS);
-            rtd.setValueURI(LOC_GOV_VOCABULARY_RELATORS + "/" + role);
             rtd.setStringValue(role);
             changeLog.log(MODS);
         }

--- a/command-migration/src/test/java/org/qucosa/migration/mappings/AdministrativeInformationMappingTest.java
+++ b/command-migration/src/test/java/org/qucosa/migration/mappings/AdministrativeInformationMappingTest.java
@@ -62,19 +62,17 @@ public class AdministrativeInformationMappingTest extends MappingTestBase {
         aim.mapDefaultPublisherInfo(opus, mods, changeLog);
 
         assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
-        assertXpathExists("//mods:name[@type='corporate' and @displayLabel='mapping-hack-university']", mods);
-        assertXpathExists("//mods:name[@type='corporate' and @displayLabel='mapping-hack-university']/" +
+        assertXpathExists("//mods:name[@type='corporate']", mods);
+        assertXpathExists("//mods:name[@type='corporate']/" +
                 "mods:nameIdentifier[@type='gnd' and text()='" + SLUB_GND_IDENTIFIER + "']", mods);
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@ref=//mods:name/@ID]", mods);
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@ref=//mods:name/@ID" +
                 " and @place='" + opus.getPublisherPlace() + "'" +
                 " and @address='" + opus.getPublisherAddress() + "']", mods);
-        assertXpathExists("//mods:extension/slub:info/slub:corporation[@ref=//mods:name/@ID]" +
-                "/slub:university[text()='" + opus.getPublisherName() + "']", mods);
-        assertXpathExists("//mods:name[@type='corporate' and @displayLabel='mapping-hack-university']/" +
+        assertXpathExists("//mods:name[@type='corporate']/" +
                 "mods:namePart[.='" + opus.getPublisherName() + "']", mods);
-        assertXpathExists("//mods:name[@type='corporate' and @displayLabel='mapping-hack-university']/" +
-                "mods:role/mods:roleTerm[@valueURI='http://id.loc.gov/vocabulary/relators/prv' and .='prv']", mods);
+        assertXpathExists("//mods:name[@type='corporate']/" +
+                "mods:role/mods:roleTerm[.='prv']", mods);
     }
 
     @Test

--- a/command-migration/src/test/java/org/qucosa/migration/mappings/CombinedModsExtensionMappingIT.java
+++ b/command-migration/src/test/java/org/qucosa/migration/mappings/CombinedModsExtensionMappingIT.java
@@ -34,8 +34,6 @@ public class CombinedModsExtensionMappingIT extends MappingTestBase {
         assertModsChanges();
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@ref=//mods:name/@ID and @type='other']" +
                 "/slub:section[text()='" + org.getSecondLevelName() + "']", mods);
-        assertXpathExists("//mods:extension/slub:info/slub:corporation[@ref=//mods:name/@ID]" +
-                "/slub:university[text()='" + opus.getPublisherName() + "']", mods);
     }
 
     @Test


### PR DESCRIPTION
Remove attribute "displayLabel" in mods:name for defaultPublisher.
Remove slub:university for defaultPublisher (now in namePart-Element).
Remove attribute "valueURI" in mods:roleTerm for all corporations.
Resolves https://jira.slub-dresden.de/browse/CMR-496