### PR TITLE
Adjust mapping of series-reference.

### DIFF
--- a/command-migration/src/main/java/org/qucosa/migration/mappings/ReferencesMapping.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/ReferencesMapping.java
@@ -47,6 +47,24 @@ import static org.qucosa.migration.org.qucosa.migration.xml.XmlFunctions.select;
 public class ReferencesMapping {
 
     public void mapSeriesReference(Document opus, ModsDefinition mods, ChangeLog changeLog) {
+
+        boolean isSeries = false;
+
+        // find first series reference
+        Reference firstReferenceUrn = null;
+        for (Reference ref : opus.getReferenceUrnArray()) {
+            if (SERIES.toString().equals(ref.getRelation())) {
+                firstReferenceUrn = ref;
+                isSeries = true;
+                break;
+            }
+        }
+
+        if (!isSeries) {
+            // skip if document type is not a series
+            return;
+        }
+
         // gathering data
         Title firstTitleParent = (Title) firstOf(opus.getTitleParentArray());
 
@@ -57,14 +75,6 @@ public class ReferencesMapping {
             volumeTitle = volumeTitle(firstTitleParent.getValue());
         }
 
-        // find first series reference
-        Reference firstReferenceUrn = null;
-        for (Reference ref : opus.getReferenceUrnArray()) {
-            if (SERIES.toString().equals(ref.getRelation())) {
-                firstReferenceUrn = ref;
-                break;
-            }
-        }
 
         String referenceUrn = null;
         String referenceSortOrder = null;

--- a/command-migration/src/test/java/org/qucosa/migration/mappings/ReferencesMappingTest.java
+++ b/command-migration/src/test/java/org/qucosa/migration/mappings/ReferencesMappingTest.java
@@ -20,6 +20,7 @@ package org.qucosa.migration.mappings;
 import noNamespace.Reference;
 import noNamespace.Title;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static java.lang.String.format;
@@ -106,6 +107,7 @@ public class ReferencesMappingTest extends MappingTestBase {
                 mods);
     }
 
+    @Ignore("Reference to parent series without URN should not be mapped anymore")
     @Test
     public void Reference_to_parent_series_without_URN_extracts_title_and_volume() {
         Title tp = opus.addNewTitleParent();
@@ -288,8 +290,11 @@ public class ReferencesMappingTest extends MappingTestBase {
     }
 
     @Test
-    public void No_series_mapping_if_reference_is_not_of_type_series() {
+    public void No_series_mapping_if_reference_is_not_of_type_series_and_titleParent_exists() {
         String urn = "urn:nbn:de:bsz:14-qucosa-74328";
+
+        Title titleParent = opus.addNewTitleParent();
+        titleParent.setValue("Parent Document");
 
         Reference refUrn = opus.addNewReferenceUrn();
         refUrn.setValue(urn);
@@ -302,5 +307,4 @@ public class ReferencesMappingTest extends MappingTestBase {
         assertXpathNotExists("//mods:relatedItem[@type='series']", mods);
         assertXpathExists("//mods:relatedItem[@type='host']", mods);
     }
-
 }


### PR DESCRIPTION
relatedItem type "series" will only be created if there is a reference
of type "series" and not if there is a TitleParent.
tested with qucosa:13565, qucosa:14879
Resolves https://jira.slub-dresden.de/browse/CMR-499