### PR TITLE
Change contributor role mapping for TUD

### DIFF
--- a/command-migration/src/main/java/org/qucosa/migration/mappings/InstitutionsMapping.java
+++ b/command-migration/src/main/java/org/qucosa/migration/mappings/InstitutionsMapping.java
@@ -153,7 +153,7 @@ public class InstitutionsMapping {
         }
     }
 
-    private void createOrganizationType(CorporationType ct, String hierarchy, String name, ChangeLog changeLog) throws XPathExpressionException {
+    private void createOrganizationType(CorporationType ct, String hierarchy, String name, ChangeLog changeLog) {
         final String mappedName = mapOrganizationName(singleline(name), institutionNameMap);
         switch (hierarchy) {
             case "institution":
@@ -280,9 +280,13 @@ public class InstitutionsMapping {
                 } else {
                     return "pbl";
                 }
+            } if ("contributor".equals(role)) {
+                return "oth";
             } else {
                 return "edt";
             }
+        } if (orgType == Organisation.Type.OTHER && "contributor".equals(role)) {
+            return "oth";
         } else {
             if ("publisher".equals(role)) {
                 return "pbl";

--- a/command-migration/src/test/java/org/qucosa/migration/mappings/InstitutionsMappingTest.java
+++ b/command-migration/src/test/java/org/qucosa/migration/mappings/InstitutionsMappingTest.java
@@ -253,7 +253,7 @@ public class InstitutionsMappingTest extends MappingTestBase {
 
         assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
         assertXpathExists("//mods:name[@type='corporate']/mods:namePart[text()='Landesamt für Umwelt']", mods);
-        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='edt']", mods);
+        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='oth']", mods);
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@type='other']", mods);
     }
 
@@ -277,7 +277,7 @@ public class InstitutionsMappingTest extends MappingTestBase {
 
         assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
         assertXpathExists("//mods:name[@type='corporate']/mods:namePart[text()='Technische Universität Dresden']", mods);
-        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='edt']", mods);
+        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='oth']", mods);
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@type='university']", mods);
     }
 
@@ -327,7 +327,7 @@ public class InstitutionsMappingTest extends MappingTestBase {
 
         assertTrue("Mapper should signalChange successful change", changeLog.hasChanges());
         assertXpathExists("//mods:name[@type='corporate']/mods:namePart[text()='Technische Universität Dresden']", mods);
-        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='edt']", mods);
+        assertXpathExists("//mods:name[@type='corporate']/mods:role/mods:roleTerm[text()='oth']", mods);
         assertXpathExists("//mods:extension/slub:info/slub:corporation[@type='university']", mods);
     }
 


### PR DESCRIPTION
Institutions with type=other|university and role=contributor where
previously mapped to role/roleTerm=edt. Now they get mapped to
role/roleTerm=oth.

Resolves https://jira.slub-dresden.de/browse/CMR-545